### PR TITLE
Prevent Overuse of ?help Suggestion

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -83,7 +83,7 @@ bot.on('message', function(user, userID, channelID, message, evt) {
    * based on if the first given character is the '?' character
    */
   if (userID === bot.id) return;
-  if (message.substring(0,1) == '?') {
+  if (/^\?\w+/.test($message)) {
     botCommands(message, evt, channelID, function(response) {
       bot.sendMessage({
         to: channelID,


### PR DESCRIPTION
Cursebot kindly suggest the help command for any message starting with `?`. This change narrows that check to messages that also have a normal word character immediately following the single `?`.

## Tests
https://jsfiddle.net/2q8tsLf3/
https://regex101.com/r/3wgEEz/2